### PR TITLE
Add .gitignore to exclude virtual environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+.env


### PR DESCRIPTION
Added a .gitignore file to exclude virtual environment files (venv/) and unnecessary Python cache files.
This ensures the repository stays clean and avoids uploading local development files.